### PR TITLE
Remove automatically added p tags

### DIFF
--- a/django_project/changes/views/changelog_github.py
+++ b/django_project/changes/views/changelog_github.py
@@ -256,6 +256,10 @@ def download_all_referenced_images(request, **kwargs):
             content = entry.description
             md = markdown.Markdown(extensions=[ImgExtExtension()])
             html = md.convert(content)
+            # The above line will add unnecessary p tags
+            # that will break the notable fixes tables
+            # So we need to remove them
+            html = html.replace('<p>', '').replace('</p>', '')
             try:
                 images = md.images
                 if len(images) > 0:


### PR DESCRIPTION
Fix for #11 and https://github.com/kartoza/prj.app/issues/1517

This will remove all the unnecessary `<p>` tags added to each entry description when we click on **Download Images** button.