### PR TITLE
Optimize images size and use webp format

### DIFF
--- a/django_project/changes/templates/entry/includes/entry_detail.html
+++ b/django_project/changes/templates/entry/includes/entry_detail.html
@@ -70,15 +70,15 @@
                 {% else %}
                     <a href="{{ entry.image_file.url }}">
                         <img class="image"
-                             src="{{ entry.image_file.url }}"
-                             alt=""/>
+                            src="{{ entry.image_file.url }}"
+                            alt=""/>
                     </a>
                 {% endif %}
             {% else %}
                 <a href="#" class="pop-image">
-                    <img id="{{ entry.image_file.url }}" class="image"
-                         src="{{ entry.image_file.url }}"
-                         alt=""/>
+                    {% thumbnail entry.image_file "1000x500" crop="center" format="WEBP" as im %}
+                        <img id="{{ entry.image_file.url }}" class="image is-rounded" src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}" alt="Version image">
+                    {% endthumbnail %}
                 </a>
             {% endif %}
         {% endif %}

--- a/django_project/changes/templates/version/detail-content.html
+++ b/django_project/changes/templates/version/detail-content.html
@@ -11,9 +11,10 @@
 <div class="columns">
     <div class="column">
         {% if not rst_download %}
-            <a href="{{ version.image_file.url }}">
-                <img class="image is-rounded"
-                    src="{{ version.image_file.url }}"/>
+        <a href="{{ version.image_file.url }}">
+                {% thumbnail version.image_file "1000x500" crop="center" format="WEBP" as im %}
+                    <img class="image is-rounded" src="{{ im.url }}" width="{{ im.width }}" height="{{ im.height }}" alt="Version image">
+                {% endthumbnail %}
             </a>
         {% else %}
             <img class="image is-rounded"


### PR DESCRIPTION
Fix for #29

This will scale the images to have a max width of 1000px and a max height of 500px and use WEBP format for an optimized page loading performance. GIF images are excluded.

Cc @phidrho